### PR TITLE
Restriction Ruby version to 3.1

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Use Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: 3.1.0
       - name: Install gem
         run: |
           gem install relaton-cli


### PR DESCRIPTION
The rdf gem doesn't work with Ruby v 3.2 yet.