### PR TITLE
chore: remove pull_request trigger

### DIFF
--- a/.github/workflows/crawler.yml
+++ b/.github/workflows/crawler.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: [ master, main ]
     tags: [ v* ]
-  pull_request:
   schedule:
   - cron: '0 14 * * *'
   workflow_dispatch:


### PR DESCRIPTION
This PR aims at disabling the crawler workflow from being triggered by pull_request event. Crawler, otherwise, is triggered daily causing conflicts between PR branches, thus making it hard to review and merge updates from maintainers.

@kesara 